### PR TITLE
check if custom url set, redirect to the url

### DIFF
--- a/src/Traits/PasswordlessLogin.php
+++ b/src/Traits/PasswordlessLogin.php
@@ -73,7 +73,7 @@ trait PasswordlessLogin
      */
     public function onPasswordlessLoginSuccess($request)
     {
-        return redirect($this->getRedirectUrlAttribute());
+        return ($request->has('redirect_to')) ? redirect($request->redirect_to) : redirect($this->getRedirectUrlAttribute());
     }
 
     /**


### PR DESCRIPTION
If the guard_name is defined, the code will fall back to onPasswordlessLoginSuccess(). However if the request contains redirect_to custom url, the code will ignore instead of use the custom url.